### PR TITLE
feat(bypass-init): Adding compile time init() function bypass mechanism

### DIFF
--- a/configure/liveconfig.go
+++ b/configure/liveconfig.go
@@ -62,8 +62,8 @@ type ServerCfg struct {
 // default config
 var defaultConf = ServerCfg{
 	ConfigFile:      "livego.yaml",
-	FLVArchive:	false,
-	RTMPNoAuth:	false,
+	FLVArchive:      false,
+	RTMPNoAuth:      false,
 	RTMPAddr:        ":1935",
 	HTTPFLVAddr:     ":7001",
 	HLSAddr:         ":7002",
@@ -82,7 +82,15 @@ var defaultConf = ServerCfg{
 	}},
 }
 
-var Config = viper.New()
+var (
+	Config = viper.New()
+
+	// BypassInit can be used to bypass the init() function by setting this
+	// value to True at compile time.
+	//
+	// go build -ldflags "-X 'github.com/gwuhaolin/livego/configure.BypassInit=true'" -o livego main.go
+	BypassInit string = ""
+)
 
 func initLog() {
 	if l, err := log.ParseLevel(Config.GetString("level")); err == nil {
@@ -92,6 +100,12 @@ func initLog() {
 }
 
 func init() {
+	if BypassInit == "" {
+		initDefault()
+	}
+}
+
+func initDefault() {
 	defer Init()
 
 	// Default config


### PR DESCRIPTION
 This feature allows a user to bypass the default command line flags that livego assumes.

 This is useful for projects that are vendoring the code directly, and do not want to assume the same command line flags as the main project.

Signed-off-by: Kris Nóva <kris@nivenly.com>